### PR TITLE
restore the API to take a generic function object

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -15,8 +15,9 @@ int main() try
 	std::iota(buf.begin(), buf.end(), 0);
 
 	// disk full or access after EOF are reported as exceptions
-	sig::iovec iov = { buf.data(), map, buf.size() };
-	sig::copy(&iov, 1);
+	sig::try_signal([&]{
+		std::memcpy(map, buf.data(), buf.size());
+	});
 
 	munmap(map, 1024);
 	close(fd);

--- a/try_signal_msvc.hpp
+++ b/try_signal_msvc.hpp
@@ -30,20 +30,32 @@ POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#ifndef TRY_SIGNAL_HPP_INCLUDED
-#define TRY_SIGNAL_HPP_INCLUDED
+#ifndef TRY_SIGNAL_MSVC_HPP_INCLUDED
+#define TRY_SIGNAL_MSVC_HPP_INCLUDED
 
-#if !defined _WIN32
-// linux
-#include "try_signal_posix.hpp"
-#elif __GNUC__
-// mingw
-#include "try_signal_mingw.hpp"
-#else
-// windows
-#include "try_signal_msvc.hpp"
+#include "signal_error_code.hpp"
+
+namespace sig {
+namespace detail {
+
+bool catch_error(int const code);
+
+} // detail namespace
+
+template <typename Fun>
+void try_signal(Fun&& f)
+{
+	__try
+	{
+		f();
+	}
+	__except (detail::catch_error(GetExceptionCode()))
+	{
+		throw std::system_error(std::error_code(GetExceptionCode(), seh_category()));
+	}
+}
+
+} // sig namespace
+
 #endif
-
-
-#endif // TRY_SIGNAL_HPP_INCLUDED
 


### PR DESCRIPTION
Still use __try, __except on msvc. document that destructors may not be called