### PR TITLE
CMake: Add install step for embedded systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,3 +4,7 @@ project(try_signal)
 add_library(try_signal signal_error_code try_signal)
 target_include_directories(try_signal PUBLIC .)
 
+file(GLOB HEADERS "*.hpp")
+
+install(TARGETS try_signal DESTINATION lib)
+install(FILES ${HEADERS} DESTINATION include)


### PR DESCRIPTION
## Description

As title says, this PR adds an install step to CMakeLists.txt. The install step is needed for including try_signal in embedded systems.

## Motivation and context

I integrated libtorrent into Kodi in 2023: https://github.com/xbmc/xbmc/pull/23696. This change was needed, and is appropriate to upstream, so I'm submitting it here.

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/23696.

Built for the following platforms:

* Android (arm, aarch64, x86)
* Linux (arm, aarch64, x86, x86_64)
* macOS (x86_64, arm64)
* iOS, TVOS
* Windows 10 (x86, x86_64)
* Windows UWP (x86, x86_64, arm)
* webos
* FreeBSD
